### PR TITLE
feat(crashlytics): emit structured JSON breadcrumb with event key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ StructuredTimber.i(
 )
 // Logcat output:
 // I/StructuredLog: Purchase completed {item_id=SKU-123, price=1980, currency=JPY}
+
+// Crashlytics breadcrumb (flat JSON, message under `event`):
+// {"event":"Purchase completed","item_id":"SKU-123","price":1980,"currency":"JPY"}
+// — and the same fields are also sent as Crashlytics custom keys.
 ```
 
 ## Features
@@ -55,7 +59,7 @@ dependencies {
 |--------|----------|-------------|
 | `structlog-timber-core` | `io.github.casl0:structlog-timber-core` | Core API: `StructuredTimber`, `StructuredTree`, `StructuredLog`, `Sink` |
 | `structlog-timber-logcat` | `io.github.casl0:structlog-timber-logcat` | `LogcatSink` -- writes structured logs to Android Logcat |
-| `structlog-timber-crashlytics` | `io.github.casl0:structlog-timber-crashlytics` | `CrashlyticsSink` -- sends fields as Crashlytics custom keys |
+| `structlog-timber-crashlytics` | `io.github.casl0:structlog-timber-crashlytics` | `CrashlyticsSink` -- sends fields as Crashlytics custom keys and records a flat JSON breadcrumb via `FirebaseCrashlytics.log()` |
 
 ### Requirements
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -18,6 +18,10 @@ StructuredTimber.i(
 )
 // Logcat 出力:
 // I/StructuredLog: Purchase completed {item_id=SKU-123, price=1980, currency=JPY}
+
+// Crashlytics のパンくず（メッセージを `event` キーに格納したフラット JSON）:
+// {"event":"Purchase completed","item_id":"SKU-123","price":1980,"currency":"JPY"}
+// — 同じフィールドは Crashlytics のカスタムキーとしても送信されます。
 ```
 
 ## 主な機能
@@ -55,7 +59,7 @@ dependencies {
 |------------|------------------|------|
 | `structlog-timber-core` | `io.github.casl0:structlog-timber-core` | コア API: `StructuredTimber`, `StructuredTree`, `StructuredLog`, `Sink` |
 | `structlog-timber-logcat` | `io.github.casl0:structlog-timber-logcat` | `LogcatSink` -- 構造化ログを Android Logcat に出力 |
-| `structlog-timber-crashlytics` | `io.github.casl0:structlog-timber-crashlytics` | `CrashlyticsSink` -- フィールドを Crashlytics のカスタムキーとして送信 |
+| `structlog-timber-crashlytics` | `io.github.casl0:structlog-timber-crashlytics` | `CrashlyticsSink` -- フィールドを Crashlytics のカスタムキーとして送信し、`FirebaseCrashlytics.log()` でフラット JSON パンくずも記録 |
 
 ### 動作要件
 

--- a/docs/WHY.md
+++ b/docs/WHY.md
@@ -83,6 +83,19 @@ StructuredTimber.e(
   automatically includes `app_version`, `session_id`, and whatever context
   you have set — without a single manual `setCustomKey()` call.
 
+The same call also records a flat JSON breadcrumb via
+`FirebaseCrashlytics.log()`, with the message stored under the `event` key
+and all fields merged at the top level, so the breadcrumb timeline is
+machine-readable end to end:
+
+```json
+{"event":"Payment failed","gateway":"stripe","retry_count":3,"user_tier":"premium"}
+```
+
+Custom keys give you the *state* at crash time; the JSON breadcrumb gives you
+the *sequence of events* leading up to it. Both are populated from the same
+log call, with no duplicate code at the call site.
+
 ---
 
 ## 3. Consistent Logs: Global Fields and Thread-Local Context

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 agp = "9.2.0"
+kotlin = "2.2.10"
+kotlinx-serialization-json = "1.7.3"
 timber = "5.0.1"
 firebase-crashlytics = "20.0.5"
 junit = "4.13.2"
@@ -19,6 +21,7 @@ minSdk = "26"
 [libraries]
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebase-crashlytics" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 junit = { module = "junit:junit", version.ref = "junit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -27,6 +30,7 @@ appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat"
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/structlog-timber-core/src/main/kotlin/io/github/casl0/structlog/extension/timber/StructuredTimber.kt
+++ b/structlog-timber-core/src/main/kotlin/io/github/casl0/structlog/extension/timber/StructuredTimber.kt
@@ -152,7 +152,9 @@ object StructuredTimber {
   /**
    * Consume and return pending fields set by the most recent log call on this thread.
    *
-   * After this call, the thread-local pending fields are cleared.
+   * After this call, the thread-local pending fields are cleared. The returned map preserves the
+   * order in which fields were passed at the call site, so downstream [Sink] implementations can
+   * rely on a deterministic iteration order.
    *
    * @return The pending fields, or an empty map if none were set.
    * @since 1.0.0
@@ -170,7 +172,9 @@ object StructuredTimber {
 
   private fun setPendingFields(fields: Array<out Pair<String, Any?>>) {
     if (fields.isNotEmpty()) {
-      val map = HashMap<String, Any?>(fields.size * 2)
+      // LinkedHashMap preserves insertion order so Sinks that serialize fields (e.g. JSON
+      // breadcrumbs) produce deterministic output even when only per-log fields are present.
+      val map = LinkedHashMap<String, Any?>(fields.size * 2)
       for ((k, v) in fields) map[k] = v
       pendingFields.set(map)
     }

--- a/structlog-timber-core/src/test/kotlin/io/github/casl0/structlog/extension/timber/StructuredTreeTest.kt
+++ b/structlog-timber-core/src/test/kotlin/io/github/casl0/structlog/extension/timber/StructuredTreeTest.kt
@@ -162,6 +162,37 @@ class StructuredTreeTest {
   }
 
   @Test
+  fun `per-log fields preserve call-site insertion order`() {
+    val sink = createSink()
+    val entrySlot = slot<StructuredLogEntry>()
+    every { sink.emit(capture(entrySlot)) } returns Unit
+    Timber.plant(StructuredTree(sinks = listOf(sink)))
+
+    StructuredTimber.d("msg", "z" to 1, "a" to 2, "m" to 3, "b" to 4)
+
+    assertEquals(listOf("z", "a", "m", "b"), entrySlot.captured.fields.keys.toList())
+  }
+
+  @Test
+  fun `merged fields preserve global then context then per-log order`() {
+    val sink = createSink()
+    val entrySlot = slot<StructuredLogEntry>()
+    every { sink.emit(capture(entrySlot)) } returns Unit
+    Timber.plant(
+      StructuredTree(sinks = listOf(sink), globalFields = linkedMapOf("g1" to "g", "g2" to "g"))
+    )
+
+    StructuredLog.putLogContext("c1", "c")
+    StructuredLog.putLogContext("c2", "c")
+    StructuredTimber.d("msg", "p1" to "p", "p2" to "p")
+
+    assertEquals(
+      listOf("g1", "g2", "c1", "c2", "p1", "p2"),
+      entrySlot.captured.fields.keys.toList(),
+    )
+  }
+
+  @Test
   fun `throwable is passed through to entry`() {
     val sink = createSink()
     val entrySlot = slot<StructuredLogEntry>()

--- a/structlog-timber-crashlytics/build.gradle.kts
+++ b/structlog-timber-crashlytics/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.dokka)
   alias(libs.plugins.kover)
   alias(libs.plugins.maven.publish)
@@ -33,6 +34,7 @@ mavenPublishing {
 dependencies {
   implementation(project(":structlog-timber-core"))
   implementation(libs.firebase.crashlytics)
+  implementation(libs.kotlinx.serialization.json)
 
   testImplementation(libs.junit)
   testImplementation(libs.mockk)

--- a/structlog-timber-crashlytics/src/main/kotlin/io/github/casl0/structlog/extension/timber/crashlytics/CrashlyticsSink.kt
+++ b/structlog-timber-crashlytics/src/main/kotlin/io/github/casl0/structlog/extension/timber/crashlytics/CrashlyticsSink.kt
@@ -4,11 +4,17 @@ import android.util.Log
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import io.github.casl0.structlog.extension.timber.Sink
 import io.github.casl0.structlog.extension.timber.StructuredLogEntry
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * A [Sink] that sends structured logs to Firebase Crashlytics.
  * - Key-value fields are set as Crashlytics custom keys.
- * - The log message is recorded via [FirebaseCrashlytics.log].
+ * - The log message and fields are recorded as a single flat JSON breadcrumb via
+ *   [FirebaseCrashlytics.log], with the message stored under the `event` key.
  * - If a [Throwable] is present, it is recorded as a non-fatal exception.
  *
  * By default, only logs at WARN level and above are sent. Override [minPriority] to change this.
@@ -41,6 +47,9 @@ class CrashlyticsSink(
    * Fields are set as custom keys with type-aware conversion for [Boolean], [Int], [Long], [Float],
    * [Double], and [String]. All other types are converted via [Any.toString].
    *
+   * The breadcrumb log records a single JSON object containing the message under the `event` key
+   * plus all fields at the top level. If a field key collides with `event`, the field wins.
+   *
    * @param entry The structured log entry to emit.
    * @since 1.0.0
    */
@@ -57,8 +66,46 @@ class CrashlyticsSink(
       }
     }
 
-    crashlytics.log(entry.message)
+    crashlytics.log(buildBreadcrumbJson(entry))
 
     entry.throwable?.let { crashlytics.recordException(it) }
   }
+
+  /**
+   * Build a flat JSON breadcrumb with the message under the `event` key and fields merged at the
+   * top level.
+   *
+   * @param entry The structured log entry to render.
+   * @return Compact JSON string.
+   */
+  private fun buildBreadcrumbJson(entry: StructuredLogEntry): String =
+    buildJsonObject {
+        put(EVENT_KEY, JsonPrimitive(entry.message))
+        for ((key, value) in entry.fields) {
+          put(key, value.toJsonElement())
+        }
+      }
+      .toString()
+
+  private companion object {
+    /** Key under which the log message is stored in the breadcrumb JSON. */
+    private const val EVENT_KEY = "event"
+  }
 }
+
+/** Convert an arbitrary value into a [JsonElement], falling back to [Any.toString] for unknowns. */
+private fun Any?.toJsonElement(): JsonElement =
+  when (this) {
+    null -> JsonNull
+    is Boolean -> JsonPrimitive(this)
+    is Number -> JsonPrimitive(this)
+    is String -> JsonPrimitive(this)
+    is Map<*, *> ->
+      buildJsonObject {
+        for ((k, v) in this@toJsonElement) {
+          put(k.toString(), v.toJsonElement())
+        }
+      }
+    is Iterable<*> -> buildJsonArray { for (v in this@toJsonElement) add(v.toJsonElement()) }
+    else -> JsonPrimitive(toString())
+  }

--- a/structlog-timber-crashlytics/src/test/kotlin/io/github/casl0/structlog/extension/timber/crashlytics/CrashlyticsSinkTest.kt
+++ b/structlog-timber-crashlytics/src/test/kotlin/io/github/casl0/structlog/extension/timber/crashlytics/CrashlyticsSinkTest.kt
@@ -24,7 +24,7 @@ class CrashlyticsSinkTest {
   }
 
   @Test
-  fun `emit sets custom keys and logs message`() {
+  fun `emit sets custom keys and logs JSON breadcrumb`() {
     val sink = CrashlyticsSink(crashlytics = crashlytics)
     val entry =
       StructuredLogEntry(
@@ -32,14 +32,14 @@ class CrashlyticsSinkTest {
         tag = "Test",
         message = "something happened",
         throwable = null,
-        fields = mapOf("user_id" to "u-1", "count" to 42),
+        fields = linkedMapOf("user_id" to "u-1", "count" to 42),
       )
 
     sink.emit(entry)
 
     verify { crashlytics.setCustomKey("user_id", "u-1") }
     verify { crashlytics.setCustomKey("count", 42) }
-    verify { crashlytics.log("something happened") }
+    verify { crashlytics.log("""{"event":"something happened","user_id":"u-1","count":42}""") }
     verify(exactly = 0) { crashlytics.recordException(any()) }
   }
 
@@ -58,7 +58,7 @@ class CrashlyticsSinkTest {
 
     sink.emit(entry)
 
-    verify { crashlytics.log("error occurred") }
+    verify { crashlytics.log("""{"event":"error occurred"}""") }
     verify { crashlytics.recordException(exception) }
   }
 
@@ -72,7 +72,7 @@ class CrashlyticsSinkTest {
         message = "typed",
         throwable = null,
         fields =
-          mapOf(
+          linkedMapOf(
             "bool" to true,
             "int" to 1,
             "long" to 2L,
@@ -92,10 +92,15 @@ class CrashlyticsSinkTest {
     verify { crashlytics.setCustomKey("double", 4.0) }
     verify { crashlytics.setCustomKey("string", "hello") }
     verify { crashlytics.setCustomKey("other", "[1, 2, 3]") }
+    verify {
+      crashlytics.log(
+        """{"event":"typed","bool":true,"int":1,"long":2,"float":3.0,"double":4.0,"string":"hello","other":[1,2,3]}"""
+      )
+    }
   }
 
   @Test
-  fun `emit with empty fields only logs message`() {
+  fun `emit with empty fields only logs event in JSON`() {
     val sink = CrashlyticsSink(crashlytics = crashlytics)
     val entry =
       StructuredLogEntry(
@@ -108,12 +113,63 @@ class CrashlyticsSinkTest {
 
     sink.emit(entry)
 
-    verify { crashlytics.log("no fields") }
+    verify { crashlytics.log("""{"event":"no fields"}""") }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<String>()) }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<Boolean>()) }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<Int>()) }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<Long>()) }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<Float>()) }
     verify(exactly = 0) { crashlytics.setCustomKey(any(), any<Double>()) }
+  }
+
+  @Test
+  fun `field with key 'event' overrides the log message in breadcrumb`() {
+    val sink = CrashlyticsSink(crashlytics = crashlytics)
+    val entry =
+      StructuredLogEntry(
+        priority = Log.WARN,
+        tag = null,
+        message = "original",
+        throwable = null,
+        fields = mapOf("event" to "overridden"),
+      )
+
+    sink.emit(entry)
+
+    verify { crashlytics.log("""{"event":"overridden"}""") }
+  }
+
+  @Test
+  fun `null field value is serialized as JSON null`() {
+    val sink = CrashlyticsSink(crashlytics = crashlytics)
+    val entry =
+      StructuredLogEntry(
+        priority = Log.WARN,
+        tag = null,
+        message = "msg",
+        throwable = null,
+        fields = mapOf("missing" to null),
+      )
+
+    sink.emit(entry)
+
+    verify { crashlytics.log("""{"event":"msg","missing":null}""") }
+  }
+
+  @Test
+  fun `string with special characters is escaped in JSON`() {
+    val sink = CrashlyticsSink(crashlytics = crashlytics)
+    val entry =
+      StructuredLogEntry(
+        priority = Log.WARN,
+        tag = null,
+        message = "say \"hi\"",
+        throwable = null,
+        fields = mapOf("path" to "C:\\tmp\\file"),
+      )
+
+    sink.emit(entry)
+
+    verify { crashlytics.log("""{"event":"say \"hi\"","path":"C:\\tmp\\file"}""") }
   }
 }


### PR DESCRIPTION
## Summary
- `CrashlyticsSink` now records its breadcrumb via `FirebaseCrashlytics.log()` as a flat JSON object: the message is stored under the `event` key, and per-log fields are merged at the top level.
- On collision between a field key and `event`, the field value wins.
- `setCustomKey` and `recordException` behaviour are unchanged — the breadcrumb (sequence) and custom keys (state at crash time) complement each other.
- Adds the `kotlinx-serialization-json` runtime and the matching Kotlin compiler plugin (pinned to 2.2.10 to match the KGP version bundled with AGP 9.2).
- README, README_ja, and `docs/WHY.md` updated to describe the new breadcrumb output.

### Example

```kotlin
StructuredTimber.w("Slow payment response", "latency_ms" to 3200, "gateway" to "stripe")
```

records:

```json
{"event":"Slow payment response","latency_ms":3200,"gateway":"stripe"}
```

## Test plan
- [x] `./gradlew :structlog-timber-crashlytics:testDebugUnitTest`
- [x] `./gradlew spotlessCheck`
- [x] Manually verify the new JSON breadcrumb shows up in a Crashlytics issue's logs section after triggering a non-fatal exception in the sample app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)